### PR TITLE
Add export progress bar

### DIFF
--- a/client/actions/workspace.js
+++ b/client/actions/workspace.js
@@ -189,5 +189,7 @@ export const setSpeed = createAction(types.SET_SPEED, (speed) => {
   return speed;
 });
 
-
+export const setExportProgress = createAction(types.SET_EXPORT_PROGRESS, (progress) => {
+  return progress;
+});
 

--- a/client/components/EventLoop/EventLoop.jsx
+++ b/client/components/EventLoop/EventLoop.jsx
@@ -1,4 +1,4 @@
-const TICK_TIME = 50; // 50 ms / tick
+const TICK_TIME = 250; // ms / tick
 
 class EventLoopManager {
   constructor(props) {
@@ -6,10 +6,15 @@ class EventLoopManager {
     this.currentTick = 0;
     this.handlers = {};
     this.isPaused = false;
+    this.elapsedTime = 0;
   }
   
   addHandler(handlerName, handler) {
     this.handlers[handlerName] = handler;
+  }
+  
+  clearHandler(handlerName) {
+    delete this.handlers[handlerName];
   }
   
   startLoop() {

--- a/client/components/EventLoop/EventLoop.jsx
+++ b/client/components/EventLoop/EventLoop.jsx
@@ -1,0 +1,55 @@
+const TICK_TIME = 50; // 50 ms / tick
+
+class EventLoopManager {
+  constructor(props) {
+    this.intervalId = null;
+    this.currentTick = 0;
+    this.handlers = {};
+    this.isPaused = false;
+  }
+  
+  addHandler(handlerName, handler) {
+    this.handlers[handlerName] = handler;
+  }
+  
+  startLoop() {
+    if (this.intervalId) {
+      console.warn('Event loop is already running');
+      return;
+    }
+    
+    console.debug(`Event loop starting at tick ${this.currentTick}`);
+    this.intervalId = setInterval(() => this.doTick(), TICK_TIME);  
+  }
+  
+  doTick() {
+    this.currentTick++;
+    console.debug(`Event tick ${this.currentTick}:`);
+    
+    for (let handler in this.handlers) {
+      if (this.handlers.hasOwnProperty(handler)) {
+        console.debug(`    ${handler}()`);
+        this.handlers[handler]();   
+      }
+    }
+  }
+  
+  pauseLoop() {
+    console.debug(`Event loop paused at tick ${this.currentTick}`);
+    clearInterval(this.intervalId);
+    this.intervalId = null;
+    this.isPaused = true; 
+  }
+ 
+  stopLoop() {
+    console.debug(`Event loop stopped after ${this.currentTick} ticks`);
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }  
+    this.currentTick = 0;
+  }
+}
+
+
+export default EventLoopManager;

--- a/client/components/Tools/Tools.jsx
+++ b/client/components/Tools/Tools.jsx
@@ -7,6 +7,7 @@ import styles from './Tools.scss';
 
 // Material
 import Toolbar from 'material-ui/lib/toolbar/toolbar';
+import LinearProgress from 'material-ui/lib/linear-progress';
 import ToolbarGroup from 'material-ui/lib/toolbar/toolbar-group';
 import ToolbarTitle from 'material-ui/lib/toolbar/toolbar-title';
 import IconButton from 'material-ui/lib/icon-button';
@@ -156,6 +157,11 @@ class Tools extends Component{
               <IconButton onClick={this.exportRecording} tooltip="Export" disabled={!this.areButtonsEnabled()}>
                 <SystemUpdateAlt />
               </IconButton>
+              
+              <LinearProgress className={this.props.playing === playingMode.EXPORT ? styles.exportProgress : styles.hidden}
+                              mode="determinate"
+                              value={this.props.exportProgress}>
+              </LinearProgress>
           </ToolbarGroup>
 
           <ToolbarGroup float="right">

--- a/client/components/Tools/Tools.scss
+++ b/client/components/Tools/Tools.scss
@@ -15,5 +15,13 @@
   margin-left: 20px;
 }
 
+.exportProgress {
+  display: inline-block !important;
+  width: 200px !important;
+  height: 15px !important;
+  margin-bottom: 4px !important;
+}
 
-
+.hidden {
+  display: none !important;
+}

--- a/client/constants/ActionTypes.js
+++ b/client/constants/ActionTypes.js
@@ -25,3 +25,4 @@ export const SPLICE_BLOCKS = 'SPLICE_BLOCKS';
 export const FLAG_BLOCK = 'FLAG_BLOCK';
 export const SPLIT_BLOCK = 'SPLIT_BLOCK';
 export const MOVE_BLOCK = 'MOVE_BLOCK';
+export const SET_EXPORT_PROGRESS = 'SET_EXPORT_PROGRESS';

--- a/client/containers/Toolbar.jsx
+++ b/client/containers/Toolbar.jsx
@@ -16,7 +16,8 @@ class Toolbar extends Component{
   shouldComponentUpdate(nextProps, nextState) {
     return (
       nextProps.playing !== this.props.playing ||
-      nextProps.toolMode !== this.props.toolMode
+      nextProps.toolMode !== this.props.toolMode ||
+      nextProps.exportProgress !== this.props.exportProgress
     );
   }
 
@@ -26,6 +27,7 @@ class Toolbar extends Component{
         <Tools toolMode={this.props.toolMode}
           playing={this.props.playing}
           cursor={this.props.cursor}
+          exportProgress={this.props.exportProgress}
           ee={this.props.ee} />
       </div>
     );

--- a/client/reducers/workspace.js
+++ b/client/reducers/workspace.js
@@ -58,7 +58,11 @@ export default handleActions({
   SET_SEEKER: (state, action) => {
     return {...state, timing: {...state.timing, seeker: Math.max(0,action.payload)}};
   },
-
+  
+  SET_EXPORT_PROGRESS: (state, action) => {
+    return {...state, timing: {...state.timing, exportProgress: Math.min(100, action.payload)}};
+  },
+  
   SET_ZOOM: (state, action) => {
     let zoom = Math.min(Math.max(action.payload, zoomLimits.LOWER), zoomLimits.UPPER);
     let zoomRatio = state.zoomLevel/zoom;


### PR DESCRIPTION
The event loops fires rapidly while the audio context is firing and calls various handlers.
Right now it's just used for the export progress but soon it will be used to modify parameters while the track is running (turn on/off effects)

Currently every handler is called every loop but soon I plan to rewrite the event loop to use Rxjs observables, allowing handlers to choose how often they are called
